### PR TITLE
fix: Support print page without techType or purpose

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,24 +7,11 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="DTPR is an open-source communication standard that enables transparency, accountability, and control for people."
     />
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="%REACT_APP_GOOGLE_FONTS_LINK%" rel="stylesheet">
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GOOGLE_ANALYTICS_KEY%"></script>
     <script>
@@ -41,15 +28,5 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/containers/Sensors/SensorPrint.tsx
+++ b/src/containers/Sensors/SensorPrint.tsx
@@ -39,8 +39,8 @@ function SensorPrint() {
   }, [sensorId]);
 
   // Make printable badge for tech type and purpose with PRIORITY 0
-  const priorityTechType = getPrintableTaxonomyProp(sensor.data?.datachain?.techType[0]);
-  const priorityPurpose = getPrintableTaxonomyProp(sensor.data?.datachain?.purpose[0]);
+  const priorityTechType = getPrintableTaxonomyProp(sensor.data?.datachain?.techType?.[0]);
+  const priorityPurpose = getPrintableTaxonomyProp(sensor.data?.datachain?.purpose?.[0]);
   return (
     <SensorPrintView
       sensorUrl={sensorUrl}


### PR DESCRIPTION
## Changes
- [x] Use optional chain to validate the existence of `techType` and `purpose` into print page
- [x] Clean up `index.html`
- [x] Add better page content description  